### PR TITLE
Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,78 @@
 
 <img src="src/public/spatial-design-system-logo-dark.png" alt="Spatial Design System logo" height="100" />
 
-This repository contains code for [Spatial Design System](https://github.com/SpatialHub-MENDELU/spatial-design-system) documentation website. It's built with [Vitepress](https://vitepress.dev/guide/what-is-vitepress).
+This repository contains code for [Spatial Design System](https://github.com/SpatialHub-MENDELU/spatial-design-system) documentation website. It's built with [VitePress](https://vitepress.dev/guide/what-is-vitepress), a static site generator powered by Vite.
 
-## Project setup
+## How to contribute?
 
-Install required dependencies
+Fork and download repository copy. Create a new branch and install required dependencies
 
 ```bash
 npm install
 ```
 
-Compiles and hot-reloads for development
+Then run this project by
 
 ```bash
 npm run dev
 ```
 
-## How to contribute?
+In project root directory navigate to `src/`. Most folders here contain markdown files that represent docs pages. Open the one that you want to edit, select a file and edit. Then commit your changes and submit a pull request. Below are useful notes on how to embed interactive examples.
 
-In project root directory navigate to `src/`. Most of folders contain markdown files that represent docs pages. Open the one that you want to edit, select file and edit. Then commit and push (if owner/dev) or submit a pull request. Below are useful notes when editing docs.
-
-Vitepress allows to use [Vue components in markdown files](https://vitepress.dev/guide/using-vue). Basic component that is used in almost every docs page is `ComponentExample.vue` in `src/vue/`. It has two tabs: one is an A-Frame scene and the other is a code snippet (for that scene). For these two tabs component has two slots. To see an example open any md file in `src/ar-vr-primitives/` or `src/ar-vr-components/`. 
-
-**NOTE**: markdown code blocks (whenever is nested in html tag) should be separated by one line.
-
-
-````
-<template #code>  
+VitePress allows to use [Vue components in markdown files](https://vitepress.dev/guide/using-vue). Basic component that is used in almost every docs page is `ComponentExample.vue` in `src/vue/`. Visually it looks like two tabs, where one is an interactive A-Frame scene and the other is a code snippet for that scene. For these two tabs the component has two slots. Before using the component you need to import it, and also *dynamically* import Spatial Design System components that you need. Here is an example of a script:
 
 ```html
-<a-scene>
-    <a-ar-row width="3" position="0 1.5 -3">
-        <a-box color="red"></a-box>
-        <a-box color="blue"></a-box>
-        <a-box color="yellow"></a-box>
-    </a-ar-row>
-    <a-sky color="#ECECEC"></a-sky>
-</a-scene>
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import ComponentExample from "../vue/ComponentExample.vue";
+
+const renderScene = ref(false);
+
+onMounted(async () => {
+  try {
+    // Here import Spatial Design System components that you need
+    await import("spatial-design-system/components/position.js");
+    renderScene.value = true;
+  } catch (e) {
+    console.error(e);
+  }
+});
+</script>
+```
+
+This is a minimal script setup. Reuse its structure across the documentation. Below example shows how to use the component inside of a markdown file:
+
+````
+<ComponentExample>
+
+<!-- Real code that will be rendered as an A-Frame embedded scene. Place your content inside of the template tag -->
+
+<template #output v-if="renderScene">
+  <a-box color="#8A8A8A" position="-0.6 1.5 -2.5"></a-box>
+  <a-box color="#03FCC6" position="0.6 1.5 -2.5" auto-scale></a-box>
+  <a-box position="0 0.95 -2.5" width="5" height="0.1" depth="1" src="../grid-light-1850w.png"></a-box>
+</template>
+
+<!-- Code that will be used for snippet. Use markdown code blocks -->
+
+<template #code>  
+
+```js
+import "spatial-design-system/components/position.js";
+```
+
+```html
+<a-box color="#03FCC6" position="0 1.5 -2.5" auto-scale></a-box>
 ```
 
 </template>
+
+</ComponentExample>
 ````
 
-If you want to add a new page or a folder with a new file, you also need to add it to the [sidebar](https://vitepress.dev/reference/default-theme-sidebar#sidebar). Navigate to `.vitepress/config.mts` and search for `sidebar`, when add a link as below:
+**NOTE**: markdown code blocks (whenever is nested in html tag) should be separated by one line. To see more examples open any markdown file in `src/ar-vr-primitives/` or `src/ar-vr-components/`. 
+
+If you want to add a new page or a folder with new files, you first need to add it to the [sidebar](https://vitepress.dev/reference/default-theme-sidebar#sidebar). Navigate to `.vitepress/config.mts` and search for `sidebar`, when add a link as shown below:
 ```js
 sidebar: [
       {
@@ -52,14 +81,11 @@ sidebar: [
         text: 'Getting started',
         items: [
           // Link for one page
-          { text: 'Introduction', link: '/getting-started/introduction' }
+          { text: 'Introduction', link: '/getting-started/introduction' },
         ]
       },
     {
-// rest of sidebar
+// Rest of the sidebar
 ```
 
-Vitepress also support [YAML frontmatter](https://vitepress.dev/guide/frontmatter).
-
-
-
+VitePress also supports [YAML frontmatter](https://vitepress.dev/guide/frontmatter).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "spatial-design-system-docs",
             "version": "1.0.0",
             "dependencies": {
-                "spatial-design-system": "^1.4.9"
+                "spatial-design-system": "^1.5.0"
             },
             "devDependencies": {
                 "vitepress": "^1.0.0-rc.28"
@@ -1931,12 +1931,12 @@
             }
         },
         "node_modules/spatial-design-system": {
-            "version": "1.4.9",
-            "resolved": "https://registry.npmjs.org/spatial-design-system/-/spatial-design-system-1.4.9.tgz",
-            "integrity": "sha512-l+mNeWhfdLwqRhnMbhXYmTltq36T/Ghafqp19BxjBalvHTRH4YfBh0+Qoqj1DzGT4csdXtSY8HH+zDWjmewaXw==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/spatial-design-system/-/spatial-design-system-1.5.3.tgz",
+            "integrity": "sha512-e1fAPRhuEzV//Q4VOS1T4Rdey3pSLFFvb1QdsUSQFh7Kjo+qfrxLGGZxTyq4hPqGVGM5ppqXdfA9P7qb0rgRQQ==",
             "dependencies": {
                 "@tweenjs/tween.js": "^23.1.1",
-                "aframe": "^1.4.2"
+                "aframe": "~1.5.0"
             }
         },
         "node_modules/super-animejs": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
         "preview":"vitepress preview"
     },
     "dependencies": {
-        "spatial-design-system":"^1.4.9"
+        "spatial-design-system":"^1.5.0"
     }
 }

--- a/src/ar-vr-components/fit-into-fov.md
+++ b/src/ar-vr-components/fit-into-fov.md
@@ -30,18 +30,20 @@ See [adaptive guidelines](/guidelines/adaptive) for more information.
 
 ## Example
 
-Applying fit-into-fov to a plane with percentage set to 90. The plane will take up max. 90% of the screen's width or height.
+Applying fit-into-fov to a plane with margin set to 10. Initially, the plane will take up the full screen's height, and then the margin will add space on the *x* and *y* axes. 
 
-The fitting happens once when the component is mounted and loaded. Emit `fit` event on the element to peform fitting manually whenever you want. 
+The margin value is a percentage value and is applied to the scale of the object by scaling it down. The actual space (scale reduction) is calculated as `visibleWidth * margin` and `visibleHeight * margin`, which are then subtracted from the object's scale.
+
+The fitting happens once when the component is mounted and loaded. Emit `fit` event on the element to perform fitting manually whenever you want. 
 Or combine it with [auto-scale](/ar-vr-components/auto-scale) to fit the object into the screen when the camera moves.
 
 <ComponentExample :fixed="true">
 
 <template #output v-if="renderScene">
 <a-plane
-position="0 1.6 -4"
-color="#03FCC6"
-fit-into-fov="percentage: 90;"
+    position="0 1.6 -4"
+    color="#03FCC6"
+    fit-into-fov="margin: 10"
 ></a-plane>
 </template>
 
@@ -53,11 +55,10 @@ import "spatial-design-system/components/position.js";
 
 ```html-vue
 <a-plane
-    position="0 1.6 -4" 
-    color="#03FCC6" 
-    fit-into-fov="percentage: 90;"
->
-</a-plane>
+    position="0 1.6 -4"
+    color="#03FCC6"
+    fit-into-fov="margin: 10"
+></a-plane>
 ```
 
 </template>
@@ -79,7 +80,7 @@ Rotate the camera using your mouse or touch to see the effect.
     color="#03FCC6"
     auto-scale
     billboard
-    fit-into-fov="percentage: 70;"
+    fit-into-fov="margin: 10;"
     follow-camera="angle: 1;"
 ></a-plane>
 <a-box position="0 -0.7 0" width="14" height="0.1" depth="14" src="../grid-light-1850w.png"></a-box>
@@ -92,15 +93,14 @@ import "spatial-design-system/components/position.js";
 ```
 
 ```html-vue
-<a-plane
+<a-plane 
     position="0 1.6 -4" 
-    color="#03FCC6" 
+    color="#03FCC6"
     auto-scale
     billboard
-    fit-into-fov="percentage: 70;"
+    fit-into-fov="margin: 10;"
     follow-camera="angle: 1;"
->
-</a-plane>
+></a-plane>
 ```
 
 </template>
@@ -111,7 +111,7 @@ import "spatial-design-system/components/position.js";
 
 | Property       | Type    | Default | Description                                                                                                                                                                 |
 |----------------|---------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _percentage_   | number  | 100     | How much of the screen's width or height is occupied by the object. For example, if you set the percentage to 50, the object would take up 50% of the screen.               |
+| _margin_   | number  | 0     | Percentage value that sets horizontal and vertical space. Basically it affects object's scale. For example, if `margin` is `20` then object's scale in both axes will be reduced by 20%. <br><br> The margin is calculated from screen dimensions and its value can be between 0 to 100.              |
 | _useFrontFace_ | boolean | false   | If `false`, the center of the object is used for calculation. For objects with bigger depth, set to `true` and see [Fitting deeper objects](#fitting-deeper-objects) below. |
 
 ## Events

--- a/src/ar-vr-components/fit-into-fov.md
+++ b/src/ar-vr-components/fit-into-fov.md
@@ -111,7 +111,7 @@ import "spatial-design-system/components/position.js";
 
 | Property       | Type    | Default | Description                                                                                                                                                                 |
 |----------------|---------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _margin_   | number (percentage)  | 0     | Adds space. Basically it affects object's scale. For example, if `margin: 10`, then object's scale will take 80% and margin 20% in total (10% for each side on the axis). <br><br> The margin is calculated from screen dimensions and its value can be between 0 and 100.              |
+| _margin_   | number (percentage)  | 0     | Adds space. Basically it affects object's scale. For example, if `margin: 10`, then object's scale will take 80% and margin 20% in total (10% for each side on the axis). <br><br> The margin is calculated from screen dimensions and its value should be between 0 and 50.              |
 | _useFrontFace_ | boolean | false   | If `false`, the center of the object is used for calculation. For objects with bigger depth, set to `true` and see [Fitting deeper objects](#fitting-deeper-objects) below. |
 
 ## Events

--- a/src/ar-vr-components/fit-into-fov.md
+++ b/src/ar-vr-components/fit-into-fov.md
@@ -30,9 +30,9 @@ See [adaptive guidelines](/guidelines/adaptive) for more information.
 
 ## Example
 
-Applying fit-into-fov to a plane with margin set to 10. Initially, the plane will take up the full screen's height, and then the margin will add space on the *x* and *y* axes. 
+Applying fit-into-fov to a plane with the margin set to 10. Initially the plane will take up the full screen's height or width, depending on the device (mobile, desktop), and then margin (space) is added. 
 
-The margin value is a percentage value and is applied to the scale of the object by scaling it down. The actual space (scale reduction) is calculated as `visibleWidth * margin` and `visibleHeight * margin`, which are then subtracted from the object's scale.
+The margin value is a percentage value and is applied to the scale of the object by scaling it down. The actual space (scale reduction) is calculated as `visibleScreenWidth * margin` or `visibleScreenHeight * margin`, depending on the device. Before calculation margin is multiplied by 2, similar to CSS. So here margin is 10, then the plane's scale will take 80% and margin 20% in total (10% for each side on the axis). 
 
 The fitting happens once when the component is mounted and loaded. Emit `fit` event on the element to perform fitting manually whenever you want. 
 Or combine it with [auto-scale](/ar-vr-components/auto-scale) to fit the object into the screen when the camera moves.
@@ -111,7 +111,7 @@ import "spatial-design-system/components/position.js";
 
 | Property       | Type    | Default | Description                                                                                                                                                                 |
 |----------------|---------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _margin_   | number  | 0     | Percentage value that sets horizontal and vertical space. Basically it affects object's scale. For example, if `margin` is `20` then object's scale in both axes will be reduced by 20%. <br><br> The margin is calculated from screen dimensions and its value can be between 0 to 100.              |
+| _margin_   | number (percentage)  | 0     | Adds space. Basically it affects object's scale. For example, if `margin: 10`, then object's scale will take 80% and margin 20% in total (10% for each side on the axis). <br><br> The margin is calculated from screen dimensions and its value can be between 0 and 100.              |
 | _useFrontFace_ | boolean | false   | If `false`, the center of the object is used for calculation. For objects with bigger depth, set to `true` and see [Fitting deeper objects](#fitting-deeper-objects) below. |
 
 ## Events

--- a/src/index.md
+++ b/src/index.md
@@ -15,5 +15,5 @@ hero:
       link: /getting-started/introduction
     - theme: alt
       text: View on GitHub
-      link: https://github.com/vuejs/vitepress
+      link: https://github.com/SpatialHub-MENDELU/spatial-design-system
 


### PR DESCRIPTION
Updated fit-into-fov page, as component no longer uses percentage of the screen, but rather margin in a CSS style. Also updated the link on the hero page to point to the Spatial Design System GitHub repository. The README has been rewritten a bit for better clarity.