### PR TITLE
Feat/Auto XR docs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,8 +9,8 @@ function crossOriginIsolationMiddleware(_, response, next) {
 
 const crossOriginIsolation = {
   name: 'cross-origin-isolation',
-  configureServer: server => { 
-    server.middlewares.use(crossOriginIsolationMiddleware); 
+  configureServer: (server) => {
+    server.middlewares.use(crossOriginIsolationMiddleware);
   },
 };
 
@@ -97,11 +97,21 @@ export default defineConfig({
         text: 'AR/VR',
         items: [
           { text: 'auto-vr', link: '/ar-vr-components/auto-vr' },
-          { text: 'controllers', link: '/ar-vr-components/controllers'},
+          { text: 'auto-xr', link: '/ar-vr-components/auto-xr' },
+          { text: 'controllers', link: '/ar-vr-components/controllers' },
           { text: 'vr-interactive', link: '/ar-vr-components/vr-interactive' },
-          { text: 'controller-attach', link: '/ar-vr-components/controller-attach' },
-          { text: 'controller-teleport', link: '/ar-vr-components/controller-teleport' },
-          { text: 'controller-movement', link: '/ar-vr-components/controller-movement' },
+          {
+            text: 'controller-attach',
+            link: '/ar-vr-components/controller-attach',
+          },
+          {
+            text: 'controller-teleport',
+            link: '/ar-vr-components/controller-teleport',
+          },
+          {
+            text: 'controller-movement',
+            link: '/ar-vr-components/controller-movement',
+          },
           {
             text: 'Placing objects in AR',
             link: '/ar-vr-components/place-object-components',
@@ -120,7 +130,7 @@ export default defineConfig({
               },
             ],
           },
-        ]
+        ],
       },
       {
         text: 'Guidelines',

--- a/src/ar-vr-components/auto-xr.md
+++ b/src/ar-vr-components/auto-xr.md
@@ -1,0 +1,99 @@
+---
+title: auto-xr
+---
+
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import ComponentExample from "../vue/ComponentExample.vue";
+
+const renderScene = ref(false);
+
+onMounted(async () => {
+  try {
+    // await import("spatial-design-system/components/autoXr.js");
+    renderScene.value = true;
+  } catch (e) {
+    console.error(e);
+  }
+});
+</script>
+
+# {{ \$frontmatter.title }}
+
+The `auto-xr` component streamlines entering immersive WebXR sessions—whether augmented reality (AR) or virtual reality (VR)—by automatically detecting the best‑supported mode and switching the scene accordingly. It can also generate a fully customizable floating button for manual entry/exit and manages the XR session life‑cycle for you.
+
+## Example
+
+Open the demo below on a WebXR‑capable device (e.g. Meta Quest Pro, iPhone + XRViewer). The component will decide whether to start in AR, VR, or stay inline.
+
+<ComponentExample :fixed="true" :hideOutput="true">
+
+<template #code>
+
+```js
+import 'spatial-design-system/components/autoXr.js';
+```
+
+```html
+<a-scene auto-xr="autoEnter: true; sessionMode: auto">
+  <!-- Here goes the scene content -->
+</a-scene>
+```
+
+</template>
+
+</ComponentExample>
+
+## Props
+
+| Property       | Type    | Default    | Description                                                                     |
+| -------------- | ------- | ---------- | ------------------------------------------------------------------------------- |
+| _autoEnter_    | boolean | true       | Automatically enter XR as soon as a session is available                        |
+| _createButton_ | boolean | true       | Create a floating button that lets users manually toggle XR                     |
+| _buttonText_   | string  | "Enter XR" | Text displayed on the button while no XR session is active                      |
+| _sessionMode_  | string  | "auto"     | Desired mode: `auto`, `ar`, `vr`, or `inline`                                   |
+| _pollInterval_ | number  | 2000       | Interval, in milliseconds, between polling attempts when looking for XR support |
+| _maxAttempts_  | number  | 10         | Maximum number of polling attempts before giving up                             |
+
+## How It Works
+
+1. The component checks for AR and VR support using both the modern WebXR API and the legacy WebVR fallback.
+2. If `autoEnter` is enabled, it tries to start the chosen `sessionMode` as soon as the scene is loaded.
+3. If XR is not immediately available, it polls every `pollInterval` ms—up to `maxAttempts` times—until support is detected.
+4. If `createButton` is true, a floating button is injected into the page so the user can manually enter or exit XR at any time.
+5. The component listens for system‑level display connection and disconnection events to update its internal state.
+6. When the session ends, the button label reverts to the original `buttonText`.
+
+## Events
+
+The component emits its own convenience events and also hooks into A‑Frame’s standard ones:
+
+```javascript
+const scene = document.querySelector('a-scene');
+
+// Custom event – XR session successfully started
+scene.addEventListener('xr-entered', (e) => {
+  console.log('XR started in', e.detail.mode);
+  // e.detail.session is the XRSession object
+});
+
+// Custom event – XR session ended
+scene.addEventListener('xr-exited', (e) => {
+  console.log('XR exited, mode was', e.detail.mode);
+});
+
+// Standard A-Frame events (AR/VR)
+scene.addEventListener('enter-vr', () => {
+  // Handle entering AR/VR
+});
+
+scene.addEventListener('exit-vr', () => {
+  // Handle exiting AR/VR
+});
+```
+
+## Notes
+
+- `sessionMode: inline` guarantees the scene will never request an XR session; it stays in traditional 2D rendering.
+- Forcing `sessionMode: vr` or `ar` will try that mode first. If the device does not support the requested mode, the component silently falls back to inline and shows an information banner.
+- Tested on Meta Quest Pro, iPhone (XRViewer), and desktop browsers.

--- a/src/ar-vr-components/auto-xr.md
+++ b/src/ar-vr-components/auto-xr.md
@@ -26,6 +26,8 @@ The `auto-xr` component streamlines entering immersive WebXR sessions—whether 
 
 Open the demo below on a WebXR‑capable device (e.g. Meta Quest Pro, iPhone + XRViewer). The component will decide whether to start in AR, VR, or stay inline.
 
+The `auto-xr` component can be used alongside other A-Frame scene properties and components. For example, you can still configure the WebXR like optional features or any other scene-level settings.
+
 <ComponentExample :fixed="true" :hideOutput="true">
 
 <template #code>

--- a/src/vue/ComponentExample.vue
+++ b/src/vue/ComponentExample.vue
@@ -7,6 +7,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  hideOutput: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 enum Tab {
@@ -21,7 +25,7 @@ enum CameraMoveDirection {
   Left = 'left',
 }
 
-const selectedTab = ref(Tab.Output);
+const selectedTab = ref(props.hideOutput ? Tab.Code : Tab.Output);
 // Below boolean is needed to avoid this problem: https://github.com/aframevr/aframe/issues/4038
 const isAframeImported = ref(false);
 const aframeScene = ref(null);
@@ -42,6 +46,8 @@ function selectTab(tab: Tab) {
 
 onMounted(async () => {
   isAframeImported.value = true;
+  if (props.hideOutput) return;
+
   registerPointerChange();
 });
 
@@ -98,6 +104,7 @@ function moveCamera(direction: CameraMoveDirection) {
   <section class="tabs">
     <div class="tabs__row">
       <button
+        v-if="!props.hideOutput"
         @click="selectTab(Tab.Output)"
         :class="{ tabs__button_selected: selectedTab === Tab.Output }"
         type="button"
@@ -117,7 +124,7 @@ function moveCamera(direction: CameraMoveDirection) {
     </div>
 
     <div
-      v-if="isAframeImported"
+      v-if="isAframeImported && !props.hideOutput"
       v-show="selectedTab === Tab.Output"
       class="tabs__content"
     >
@@ -142,7 +149,10 @@ function moveCamera(direction: CameraMoveDirection) {
       <slot name="code"></slot>
     </div>
 
-    <div class="move-controls tabs__move-controls" v-if="showMoveControllers">
+    <div
+      class="move-controls tabs__move-controls"
+      v-if="showMoveControllers && !props.hideOutput"
+    >
       <VPButton
         class="move-controls__button move-controls__button_forward"
         v-html="moveControllersIcons.forward"
@@ -165,11 +175,11 @@ function moveCamera(direction: CameraMoveDirection) {
       />
     </div>
 
-    <p class="tabs__note" v-if="showMoveControllers">
+    <p class="tabs__note" v-if="showMoveControllers && !props.hideOutput">
       Tap and hold your finger on the scene and drag it to rotate.
     </p>
 
-    <p class="tabs__note" v-else-if="!props.fixed">
+    <p class="tabs__note" v-else-if="!props.fixed && !props.hideOutput">
       Use the mouse to rotate the scene.
     </p>
   </section>


### PR DESCRIPTION
Added docs for the [Auto XR component](https://github.com/SpatialHub-MENDELU/spatial-design-system/pull/40)

⚠️ Updated ComponentExample to hide Output tab when the demo is not available - f.e. in this component its hard to present demo. Also noticed its problematic in other AR/VR components, so that user can see directly Code.