### PR TITLE
Fix: clean imports, missing events

### DIFF
--- a/src/ar-vr-components/finger-touch.md
+++ b/src/ar-vr-components/finger-touch.md
@@ -31,11 +31,10 @@ Add the `finger-touch` component to any entity that should respond to hand touch
 <template #code>
 
 ```js
-import 'spatial-design-system/components/auto-xr.js';
+import 'spatial-design-system/components/autoXr.js';
 import 'spatial-design-system/components/hands.js';
 import 'spatial-design-system/components/finger-touch.js';
 import 'spatial-design-system/primitives/ar-button.js';
-import 'spatial-design-system/primitives/ar-textbox.js';
 ```
 
 ```html

--- a/src/ar-vr-components/grabbable.md
+++ b/src/ar-vr-components/grabbable.md
@@ -34,13 +34,14 @@ This component is mainly prepared for hand gestures. You should use it with the 
 <template #code>
 
 ```js
+import 'spatial-design-system/components/autoXr.js';
 import 'spatial-design-system/components/hands.js';
 ```
 
 ```html
-<a-scene>
+<a-scene auto-xr>
   <a-entity id="rig" hands></a-entity>
-  <a-box position="0 1.5 -2" grabbable></a-box>
+  <a-box position="0 1.5 -0.5" grabbable></a-box>
 </a-scene>
 ```
 

--- a/src/ar-vr-components/hands-hoverable.md
+++ b/src/ar-vr-components/hands-hoverable.md
@@ -1,5 +1,5 @@
 ---
-title: ar-hoverable
+title: hands-hoverable
 ---
 
 <script setup lang="ts">
@@ -30,22 +30,23 @@ This component is mainly prepared for hand gestures. You should use it with the 
 <template #code>
 
 ```js
+import 'spatial-design-system/components/autoXr.js';
 import 'spatial-design-system/components/hands.js';
 import 'spatial-design-system/components/hands-hoverable.js';
 ```
 
 ```html
-<a-scene>
+<a-scene auto-xr>
   <a-entity id="rig" hands></a-entity>
   <a-box
-    position="0 1.5 -2"
+    position="0 1.5 -0.5"
     hands-hoverable="useWireframe: true; hoverColor:#fc0000;"
   ></a-box>
   <!-- or this component will use overlay geometry by default -->
   <a-ar-button
     content="Click Me"
     hands-hoverable="hoverColor: #fc0000;"
-    position="1 2 -2"
+    position="1.5 1.5 -0.5"
   ></a-ar-button>
 </a-scene>
 ```

--- a/src/ar-vr-components/hands.md
+++ b/src/ar-vr-components/hands.md
@@ -30,7 +30,7 @@ Below is an example showing how to use the `hands` component in a scene. Try thi
 <template #code>
 
 ```js
-import 'spatial-design-system/components/auto-xr.js';
+import 'spatial-design-system/components/autoXr.js';
 import 'spatial-design-system/components/hands.js';
 import 'spatial-design-system/components/finger-touch.js';
 import 'spatial-design-system/primitives/ar-button.js';
@@ -44,7 +44,7 @@ import 'spatial-design-system/primitives/ar-button.js';
   <!-- This button shows how to add interactive component to the scene -->
   <a-ar-button
     finger-touch
-    position="0 1.5 -1"
+    position="0 1.5 -0.5"
     content="Button"
     primary="#018A6C"
     textcolor="white"

--- a/src/ar-vr-components/stretchable.md
+++ b/src/ar-vr-components/stretchable.md
@@ -47,7 +47,7 @@ Below is an example showing how to use the `stretchable` component in a scene. T
 <template #code>
 
 ```js
-import 'spatial-design-system/components/auto-xr.js';
+import 'spatial-design-system/components/autoXr.js';
 import 'spatial-design-system/components/hands.js';
 import 'spatial-design-system/components/controllers.js';
 import 'spatial-design-system/components/stretchable.js';
@@ -96,6 +96,14 @@ import 'spatial-design-system/components/stretchable.js';
 | `minSize`                 | number | `0.5`           | Minimum allowed size multiplier applied to the original scale of the object.                                |
 | `maxBoxTouchDistance`     | number | `0.03`          | Distance (in meters) within which a gesture must be to consider the object’s bounding box as “touching.”    |
 | `maxCornerSelectDistance` | number | `0.06`          | Distance threshold for selecting the nearest corner of the bounding box. Looser than `maxBoxTouchDistance`. |
+
+## Events
+
+| Event             | Parameters                                                 | Description                                                                                                                                                                                                                                    |
+| ----------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stretch-started` | `{ handOrController, intersectionPoint, pinchState }`      | Fired when a valid stretch gesture begins. Includes the input source (`hand` or `controller`), the world-space point of the initial pinch/touch, and an internal `pinchState` snapshot storing initial scale, axes, and corner selection data. |
+| `stretch-moved`   | `{ handOrController, currentPoint, newScale, pinchState }` | Fired continuously during stretching. Provides current world-space gesture position, the updated scale applied to the object, and the original `pinchState` used to compute scaling.                                                           |
+| `stretch-ended`   | `{ handOrController, finalScale, pinchState }`             | Fired when the stretch gesture finishes. Contains the gesture source, the final applied scale, and the full `pinchState` from the interaction session.                                                                                         |
 
 ## Features
 

--- a/src/ar-vr-components/touch-raycaster.md
+++ b/src/ar-vr-components/touch-raycaster.md
@@ -35,10 +35,9 @@ Add the `touch-raycaster` component to the `<a-scene>` to enable touch gesture s
 <template #code>
 
 ```js
-import 'spatial-design-system/components/auto-xr.js';
+import 'spatial-design-system/components/autoXr.js';
 import 'spatial-design-system/components/touch-raycaster.js';
 import 'spatial-design-system/primitives/ar-button.js';
-import 'spatial-design-system/primitives/ar-textbox.js';
 ```
 
 ```html


### PR DESCRIPTION
- Clear imports
- Change positions of example elements
- change title of hands-hoverable component
- add docs for stretchable events